### PR TITLE
use partial_search to avoid blowing out RAM

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,3 +6,5 @@ description       'Dyanmically generates /etc/ssh/known_hosts based on search in
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '0.7.4'
 recipe            'ssh_known_hosts', 'Provides an LWRP for managing SSH known hosts. Also includes a recipe for automatically adding all nodes to the SSH known hosts.'
+
+depends "partial_search"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,11 +28,19 @@ if Chef::Config[:solo]
   # On Chef Solo, we still want the current node to be in the ssh_known_hosts
   hosts = [node]
 else
-  hosts = search(:node, 'keys_ssh:*').collect do |host|
-    {
-      'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
-      'key'  => host['keys']['ssh']['host_rsa_public'] || host['keys']['ssh']['host_dsa_public']
-    }
+  hosts = partial_search(:node, "keys_ssh:* NOT name:#{node.name}",
+                         :keys => {
+                           'hostname' => [ 'hostname' ],
+                           'fqdn'     => [ 'fqdn' ],
+                           'ipaddress' => [ 'ipaddress' ],
+                           'host_rsa_public' => [ 'keys', 'ssh', 'host_rsa_public' ],
+                           'host_dsa_public' => [ 'keys', 'ssh', 'host_dsa_public' ]
+                         }
+                        ).collect do |host|
+                          {
+                            'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
+                            'key' => host['host_rsa_public'] || host['host_dsa_public']
+                          }
   end
 end
 


### PR DESCRIPTION
node search on a large org will return JSON objects for every node in the environment which will make ruby sad and explode the size of the ruby VM.  use partial_search to only pull ssh keys from all the nodes instead.
