### PR TITLE
prevent TypeError identified in COOK-3113

### DIFF
--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -19,7 +19,7 @@
 
 action :create do
   key = (new_resource.key || `ssh-keyscan -H #{new_resource.host} 2>&1`)
-  comment = key.split("\n").first
+  comment = key.split("\n").first || ""
 
   Chef::Application.fatal! "Could not resolve #{new_resource.host}" if key =~ /getaddrinfo/
 


### PR DESCRIPTION
I was finding that on the RHEL5 Vagrant boxes, the call to `ssh-keyscan -H #{new_resource.host}` was returning an empty string, leading to a nil value for for the comment.

I'm not entirely sure what the most appropriate action to that command coming back empty is, but this PR will at least prevent the cookbook from killing the Chef run.
