### PR TITLE
[COOK-3453] Ensure entry resource is idempotent

### DIFF
--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -35,7 +35,6 @@ action :create do
         file.puts key
       end
     end
-    new_resource.updated_by_last_action(true)
   end
 end
 


### PR DESCRIPTION
Here's another approach to https://github.com/opscode-cookbooks/ssh_known_hosts/pull/9.

This uses ruby directly instead of using a ruby_block.  This simplifies the provider, adds whyrun support, and fixes the idempotent issue.  Also, since it is no longer using `Chef::Util::FileEdit`, it doesn't require adding a comment to the known_hosts file.

COOK-3453
