### PR TITLE
Allow specification of custom known hosts in attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Searches the Chef Server for all hosts that have SSH host keys and generates an 
 
 #### Adding custom host keys
 
-There are two ways to add custom host keys. You can either use the provided LWRP (see above), or by creating a data bag called "`ssh_known_hosts`" and adding an item for each host:
+There are three ways to add custom host keys. You can either use the provided LWRP (see above), or by creating a data bag called "`ssh_known_hosts`" and adding an item for each host:
 
 ```javascript
 {
@@ -96,7 +96,16 @@ There are two ways to add custom host keys. You can either use the provided LWRP
 }
 ```
 
-There are additional optional values you may use in the data bag:
+Alternatively, you can add known hosts to attributes in the `node[:ssh_known_hosts][:known_hosts]` array as:
+
+```javascript
+{
+  "fqdn": "github.com",
+  "rsa": "github-rsa-host-key"
+}
+```
+
+There are additional optional values you may use in the data bag and attribute methods:
 
 <table>
   <thead>
@@ -111,7 +120,7 @@ There are additional optional values you may use in the data bag:
   <tbody>
     <tr>
       <td>id</td>
-      <td>a unique id for this data bag entry</td>
+      <td>a unique id for this data bag entry (data bag method only)</td>
       <td><tt>github</tt></td>
       <td></td>
     </tr>
@@ -154,6 +163,7 @@ License and Authors
 - Author: Scott M. Likens (<scott@likens.us>)
 - Author: Seth Vargo (<sethvargo@gmail.com>)
 - Author: Lamont Granquist (<lamont@opscode.com>)
+- Author: Andy Rossmeissl (<andy@rossmeissl.net>)
 
 ```text
 Copyright:: 2011-2013, Opscode, Inc

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ License and Authors
 - Author: Scott M. Likens (<scott@likens.us>)
 - Author: Seth Vargo (<sethvargo@gmail.com>)
 - Author: Lamont Granquist (<lamont@opscode.com>)
-- Author: Andy Rossmeissl (<andy@rossmeissl.net>)
 
 ```text
 Copyright:: 2011-2013, Opscode, Inc

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 #
 
 default['ssh_known_hosts']['file'] = '/etc/ssh/ssh_known_hosts'
+default['ssh_known_hosts']['known_hosts'] = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,6 +58,14 @@ rescue
   Chef::Log.info "Could not load data bag 'ssh_known_hosts'"
 end
 
+# Add data from attributes to the list of nodes.
+hosts += node[:ssh_known_hosts][:known_hosts].map do |known_host|
+  {
+    'fqdn' => known_host['fqdn'] || known_host['ipaddress'] || known_host['hostname'],
+    'key'  => known_host['rsa'] || known_host['dsa']
+  }
+end
+
 # Loop over the hosts and add 'em
 hosts.each do |host|
   unless host['key'].nil?


### PR DESCRIPTION
This is especially useful for specifying them in a Vagrantfile.