### PR TITLE
Do not hash public keys

### DIFF
--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -24,7 +24,7 @@ def whyrun_supported?
 end
 
 action :create do
-  key = (new_resource.key || `ssh-keyscan -H -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}`)
+  key = (new_resource.key || `ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}`)
   comment = key.split("\n").first || ""
 
   if key_exists?(key, comment)


### PR DESCRIPTION
Hashes are different on each ssh-keyscan run, therefore filling up `/etc/ssh/ssh_known hosts`

An alternative would be, to only check for duplicate keys (not comments), but this would result in problems for hosts with multiple hostnames/ips.
