### PR TITLE
Use of the ssh_known_hosts data bag is optional.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,16 +46,18 @@ end
 
 # Add the data from the data_bag to the list of nodes.
 # We need to rescue in case the data_bag doesn't exist.
-begin
-  hosts += data_bag('ssh_known_hosts').collect do |item|
-    entry = data_bag_item('ssh_known_hosts', item)
-    {
-      'fqdn' => entry['fqdn'] || entry['ipaddress'] || entry['hostname'],
-      'key'  => entry['rsa'] || entry['dsa']
-    }
+if Chef::DataBag.list.key?('ssh_known_hosts')
+  begin
+    hosts += data_bag('ssh_known_hosts').collect do |item|
+      entry = data_bag_item('ssh_known_hosts', item)
+      {
+        'fqdn' => entry['fqdn'] || entry['ipaddress'] || entry['hostname'],
+        'key'  => entry['rsa'] || entry['dsa']
+      }
+    end
+  rescue
+    Chef::Log.info "Could not load data bag 'ssh_known_hosts'"
   end
-rescue
-  Chef::Log.info "Could not load data bag 'ssh_known_hosts'"
 end
 
 # Loop over the hosts and add 'em


### PR DESCRIPTION
This suppresses 'ERROR: Failed to list data bag items in data bag:
"ssh_known_hosts"' from appearing in the client logs if the
ssh_known_hosts data bag is not present.
