### PR TITLE
Add support for ECDSA and ED25519 keys

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -10,4 +10,29 @@ module SshknownhostsCookbook
       return OpenStruct.new(cipher: cipher, key: key) if key
     end
   end
+
+  module KeysSearch
+    extend Chef::DSL::DataQuery
+
+    def self.hosts_keys(pattern)
+      partial_search(
+        :node, pattern,
+        keys: {
+          'hostname'        => ['hostname'],
+          'fqdn'            => ['fqdn'],
+          'ipaddress'       => ['ipaddress'],
+          'host_rsa_public' => %w(keys ssh host_rsa_public),
+          'host_dsa_public' => %w(keys ssh host_dsa_public),
+          'host_ecdsa_public' => %w(keys ssh host_ecdsa_public),
+          'host_ed25519_public' => %w(keys ssh host_ed25519_public)
+        }
+      ).collect do |host|
+        {
+          'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
+          'key' => SshknownhostsCookbook.key_from(host).key,
+          'key_type' => SshknownhostsCookbook.key_from(host).cipher
+        }
+      end
+    end
+  end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,13 @@
+module SshknownhostsCookbook
+  def self.key_from(host)
+    key_types = {
+      'ssh-ed25519' => host['host_ed25519_public'],
+      'ecdsa-sha2-nistp256' => host['host_ecdsa_public'],
+      'ssh-rsa' => host['host_rsa_public'],
+      'ssh-dsa' => host['host_dsa_public']
+    }
+    key_types.each do |cipher, key|
+      return OpenStruct.new(cipher: cipher, key: key) if key
+    end
+  end
+end

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -43,12 +43,14 @@ action :create do
   if key_exists?(key, comment)
     Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
   else
+    require 'English'
+
     new_keys = (keys + [key]).uniq.sort
     file "ssh_known_hosts-#{new_resource.name}" do
       path node['ssh_known_hosts']['file']
       action :create
       backup false
-      content "#{new_keys.join($INPUT_RECORD_SEPARATOR)}#{$INPUT_RECORD_SEPARATOR}"
+      content "#{new_keys.join($RS)}#{$RS}"
     end
   end
 end

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -51,6 +51,7 @@ action :create do
       action :create
       backup false
       content "#{new_keys.join($RS)}#{$RS}"
+      mode 0644
     end
   end
 end

--- a/recipes/cacher.rb
+++ b/recipes/cacher.rb
@@ -10,12 +10,14 @@ else
       'fqdn'            => ['fqdn'],
       'ipaddress'       => ['ipaddress'],
       'host_rsa_public' => %w(keys ssh host_rsa_public),
-      'host_dsa_public' => %w(keys ssh host_dsa_public)
+      'host_dsa_public' => %w(keys ssh host_dsa_public),
+      'host_ecdsa_public' => %w(keys ssh host_ecdsa_public),
+      'host_ed25519_public' => %w(keys ssh host_ed25519_public)
     }
   ).collect do |host|
     {
       'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
-      'key' => host['host_rsa_public'] || host['host_dsa_public']
+      'key' => host['host_ed25519_public'] || host['host_ecdsa_public'] || host['host_rsa_public'] || host['host_dsa_public']
     }
   end
   Chef::Log.debug("Partial search got: #{all_host_keys.inspect}")

--- a/recipes/cacher.rb
+++ b/recipes/cacher.rb
@@ -17,7 +17,8 @@ else
   ).collect do |host|
     {
       'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
-      'key' => host['host_ed25519_public'] || host['host_ecdsa_public'] || host['host_rsa_public'] || host['host_dsa_public']
+      'key' => SshknownhostsCookbook.key_from(host).key,
+      'key_type' => SshknownhostsCookbook.key_from(host).cipher
     }
   end
   Chef::Log.debug("Partial search got: #{all_host_keys.inspect}")

--- a/recipes/cacher.rb
+++ b/recipes/cacher.rb
@@ -3,24 +3,7 @@ if Chef::Config[:solo]
   raise 'ssh_known_hosts::cacher requires Chef search - Chef Solo does ' \
     'not support search!'
 else
-  all_host_keys = partial_search(
-    :node, 'keys:*',
-    keys: {
-      'hostname'        => ['hostname'],
-      'fqdn'            => ['fqdn'],
-      'ipaddress'       => ['ipaddress'],
-      'host_rsa_public' => %w(keys ssh host_rsa_public),
-      'host_dsa_public' => %w(keys ssh host_dsa_public),
-      'host_ecdsa_public' => %w(keys ssh host_ecdsa_public),
-      'host_ed25519_public' => %w(keys ssh host_ed25519_public)
-    }
-  ).collect do |host|
-    {
-      'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
-      'key' => SshknownhostsCookbook.key_from(host).key,
-      'key_type' => SshknownhostsCookbook.key_from(host).cipher
-    }
-  end
+  all_host_keys = SshknownhostsCookbook::KeysSearch.hosts_keys('keys:*')
   Chef::Log.debug("Partial search got: #{all_host_keys.inspect}")
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,7 +53,8 @@ else
                         ).collect do |host|
     {
       'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
-      'key' => host['host_ed25519_public'] || host['host_ecdsa_public'] || host['host_rsa_public'] || host['host_dsa_public']
+      'key' => SshknownhostsCookbook.key_from(host).key,
+      'key_type' => SshknownhostsCookbook.key_from(host).cipher
     }
   end
 end
@@ -66,7 +67,7 @@ if Chef::DataBag.list.key?('ssh_known_hosts')
       entry = data_bag_item('ssh_known_hosts', item)
       {
         'fqdn' => entry['fqdn'] || entry['ipaddress'] || entry['hostname'],
-        'key'  => entry['rsa'] || entry['dsa']
+        'key'  => entry['ed25519'] || entry['ecdsa'] || entry['rsa'] || entry['dsa']
       }
     end
   rescue
@@ -80,6 +81,7 @@ hosts.each do |host|
     # The key was specified, so use it
     ssh_known_hosts_entry host['fqdn'] do
       key host['key']
+      key_type host['key_type']
     end
   else
     # No key specified, so have known_host perform a DNS lookup

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,23 +40,7 @@ elsif Chef::Config[:solo]
   # On Chef Solo, we still want the current node to be in the ssh_known_hosts
   hosts = [node]
 else
-  hosts = partial_search(:node, "keys_ssh:* NOT name:#{node.name}",
-                         keys: {
-                           'hostname' => ['hostname'],
-                           'fqdn'     => ['fqdn'],
-                           'ipaddress' => ['ipaddress'],
-                           'host_rsa_public' => %w(keys ssh host_rsa_public),
-                           'host_dsa_public' => %w(keys ssh host_dsa_public),
-                           'host_ecdsa_public' => %w(keys ssh host_ecdsa_public),
-                           'host_ed25519_public' => %w(keys ssh host_ed25519_public)
-                         }
-                        ).collect do |host|
-    {
-      'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
-      'key' => SshknownhostsCookbook.key_from(host).key,
-      'key_type' => SshknownhostsCookbook.key_from(host).cipher
-    }
-  end
+  hosts = SshknownhostsCookbook::KeysSearch.hosts_keys("keys_ssh:* NOT name:#{node.name}")
 end
 
 # Add the data from the data_bag to the list of nodes.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,12 +46,14 @@ else
                            'fqdn'     => ['fqdn'],
                            'ipaddress' => ['ipaddress'],
                            'host_rsa_public' => %w(keys ssh host_rsa_public),
-                           'host_dsa_public' => %w(keys ssh host_dsa_public)
+                           'host_dsa_public' => %w(keys ssh host_dsa_public),
+                           'host_ecdsa_public' => %w(keys ssh host_ecdsa_public),
+                           'host_ed25519_public' => %w(keys ssh host_ed25519_public)
                          }
                         ).collect do |host|
     {
       'fqdn' => host['fqdn'] || host['ipaddress'] || host['hostname'],
-      'key' => host['host_rsa_public'] || host['host_dsa_public']
+      'key' => host['host_ed25519_public'] || host['host_ecdsa_public'] || host['host_rsa_public'] || host['host_dsa_public']
     }
   end
 end

--- a/test/integration/cacher-client/serverspec/default_spec.rb
+++ b/test/integration/cacher-client/serverspec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Known Hosts' do
   describe file('/etc/ssh/ssh_known_hosts') do
     its(:content) { should include 'TEST_RSA_PUBLIC_KEY_HOST-1' }
-    its(:content) { should include 'TEST_RSA_PUBLIC_KEY_HOST-2' }
-    its(:content) { should include 'TEST_RSA_PUBLIC_KEY_HOST-3' }
+    its(:content) { should include 'TEST_ECDSA_PUBLIC_KEY_HOST-2' }
+    its(:content) { should include 'TEST_ED25519_PUBLIC_KEY_HOST-3' }
   end
 end

--- a/test/integration/cacher-client/serverspec/default_spec.rb
+++ b/test/integration/cacher-client/serverspec/default_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'Known Hosts' do
   describe file('/etc/ssh/ssh_known_hosts') do
-    its(:content) { should include 'TEST_RSA_PUBLIC_KEY_HOST-1' }
-    its(:content) { should include 'TEST_ECDSA_PUBLIC_KEY_HOST-2' }
-    its(:content) { should include 'TEST_ED25519_PUBLIC_KEY_HOST-3' }
+    its(:content) { should include "TEST_RSA_PUBLIC_KEY_HOST-1\n" }
+    its(:content) { should include "TEST_ECDSA_PUBLIC_KEY_HOST-2\n" }
+    its(:content) { should include "TEST_ED25519_PUBLIC_KEY_HOST-3\n" }
   end
 end

--- a/test/integration/cacher-client/serverspec/default_spec.rb
+++ b/test/integration/cacher-client/serverspec/default_spec.rb
@@ -5,5 +5,7 @@ describe 'Known Hosts' do
     its(:content) { should include "TEST_RSA_PUBLIC_KEY_HOST-1\n" }
     its(:content) { should include "TEST_ECDSA_PUBLIC_KEY_HOST-2\n" }
     its(:content) { should include "TEST_ED25519_PUBLIC_KEY_HOST-3\n" }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
   end
 end

--- a/test/integration/cacher/serverspec/default_spec.rb
+++ b/test/integration/cacher/serverspec/default_spec.rb
@@ -4,8 +4,8 @@ describe 'Known Hosts' do
   # This here is some serious voodoo but it SHOULD work and provide a good
   # test.
   describe file('/tmp/kitchen/data_bags/server_data/known_hosts.json') do
-    its(:content) { should include 'TEST_RSA_PUBLIC_KEY_HOST-1' }
-    its(:content) { should include 'TEST_ECDSA_PUBLIC_KEY_HOST-2' }
-    its(:content) { should include 'TEST_ED25519_PUBLIC_KEY_HOST-3' }
+    its(:content) { should include '"TEST_RSA_PUBLIC_KEY_HOST-1"' }
+    its(:content) { should include '"TEST_ECDSA_PUBLIC_KEY_HOST-2"' }
+    its(:content) { should include '"TEST_ED25519_PUBLIC_KEY_HOST-3"' }
   end
 end

--- a/test/integration/data_bags/server_data/known_hosts.json
+++ b/test/integration/data_bags/server_data/known_hosts.json
@@ -7,11 +7,11 @@
     },
     {
       "fqdn": "host-2.vagrantup.com",
-      "key": "TEST_RSA_PUBLIC_KEY_HOST-2"
+      "key": "TEST_ECDSA_PUBLIC_KEY_HOST-2"
     },
     {
       "fqdn": "host-3.vagrantup.com",
-      "key": "TEST_RSA_PUBLIC_KEY_HOST-3"
+      "key": "TEST_ED25519_PUBLIC_KEY_HOST-3"
     }
   ]
 }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -7,5 +7,7 @@ describe 'Known Hosts' do
     its(:content) { should include "ssh-rsa TEST_RSA_PUBLIC_KEY_HOST-1\n" }
     its(:content) { should include "ecdsa-sha2-nistp256 TEST_ECDSA_PUBLIC_KEY_HOST-2\n" }
     its(:content) { should include "ssh-ed25519 TEST_ED25519_PUBLIC_KEY_HOST-3\n" }
+    it { should be_mode 644 }
+    it { should be_owned_by 'root' }
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -4,8 +4,8 @@ describe 'Known Hosts' do
   # This here is some serious voodoo but it SHOULD work and provide a good
   # test.
   describe file('/etc/ssh/ssh_known_hosts') do
-    its(:content) { should include 'TEST_RSA_PUBLIC_KEY_HOST-1' }
-    its(:content) { should include 'TEST_ECDSA_PUBLIC_KEY_HOST-2' }
-    its(:content) { should include 'TEST_ED25519_PUBLIC_KEY_HOST-3' }
+    its(:content) { should include "ssh-rsa TEST_RSA_PUBLIC_KEY_HOST-1\n" }
+    its(:content) { should include "ecdsa-sha2-nistp256 TEST_ECDSA_PUBLIC_KEY_HOST-2\n" }
+    its(:content) { should include "ssh-ed25519 TEST_ED25519_PUBLIC_KEY_HOST-3\n" }
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Known Hosts' do
   # This here is some serious voodoo but it SHOULD work and provide a good
   # test.
-  describe file('/tmp/kitchen/data_bags/server_data/known_hosts.json') do
+  describe file('/etc/ssh/ssh_known_hosts') do
     its(:content) { should include 'TEST_RSA_PUBLIC_KEY_HOST-1' }
     its(:content) { should include 'TEST_ECDSA_PUBLIC_KEY_HOST-2' }
     its(:content) { should include 'TEST_ED25519_PUBLIC_KEY_HOST-3' }

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+require 'pathname'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'

--- a/test/integration/nodes/host-2.json
+++ b/test/integration/nodes/host-2.json
@@ -7,7 +7,8 @@
     "keys": {
       "ssh": {
         "host_rsa_public": "TEST_RSA_PUBLIC_KEY_HOST-2",
-        "host_dsa_public": "TEST_DSA_PUBLIC_KEY_HOST-2"
+        "host_dsa_public": "TEST_DSA_PUBLIC_KEY_HOST-2",
+        "host_ecdsa_public": "TEST_ECDSA_PUBLIC_KEY_HOST-2"
       }
     }
   }

--- a/test/integration/nodes/host-3.json
+++ b/test/integration/nodes/host-3.json
@@ -7,7 +7,9 @@
     "keys": {
       "ssh": {
         "host_rsa_public": "TEST_RSA_PUBLIC_KEY_HOST-3",
-        "host_dsa_public": "TEST_DSA_PUBLIC_KEY_HOST-3"
+        "host_dsa_public": "TEST_DSA_PUBLIC_KEY_HOST-3",
+        "host_ecdsa_public": "TEST_ECDSA_PUBLIC_KEY_HOST-3",
+        "host_ed25519_public": "TEST_ED25519_PUBLIC_KEY_HOST-3"
       }
     }
   }


### PR DESCRIPTION
### Description

Adds suport for ed25519 and ecdsa elliptic curve host keys as they are safer and shorter.

### Development tasks

- Create a `default` serverspec suite
- Get `ed25519` and `ecdsa` host keys before RSA and DSA keys
- Add `key_type` depending on the key
- Refactor search
- Fix separator
- Tight specs

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD