### PR TITLE
Handle nonstandard ssh port

### DIFF
--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -34,21 +34,21 @@ action :create do
                  new_resource.key_type
                end
 
-    if new_resource.port != 22
-      key = "[#{new_resource.host}]:#{new_resource.port} #{key_type} #{new_resource.key}"
-    else
-      key = "#{new_resource.host} #{key_type} #{new_resource.key}"
-    end
+    key = if new_resource.port != 22
+            "[#{new_resource.host}]:#{new_resource.port} #{key_type} #{new_resource.key}"
+          else
+            "#{new_resource.host} #{key_type} #{new_resource.key}"
+          end
 
   else
 
     keyscan_result = `ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}`
 
-    if new_resource.port != 22
-      key = keyscan_result.sub(/^#{new_resource.host}/, "[#{new_resource.host}]:#{new_resource.port}")
-    else
-      key = keyscan_result
-    end
+    key = if new_resource.port != 22
+            keyscan_result.sub(/^#{new_resource.host}/, "[#{new_resource.host}]:#{new_resource.port}")
+          else
+            keyscan_result
+          end
 
   end
   comment = key.split("\n").first || ''

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require 'English'
+
 use_inline_resources if defined?(use_inline_resources)
 
 def whyrun_supported?
@@ -37,7 +39,7 @@ action :create do
     else
       key = "#{new_resource.host} #{key_type} #{new_resource.key}"
     end
-    
+
   else
 
     keyscan_result = `ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}`
@@ -47,7 +49,7 @@ action :create do
     else
       key = keyscan_result
     end
-    
+
   end
   comment = key.split("\n").first || ''
 

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -32,11 +32,22 @@ action :create do
                  new_resource.key_type
                end
 
-    key = "#{new_resource.host} #{key_type} #{new_resource.key}"
-
+    if new_resource.port != 22
+      key = "[#{new_resource.host}]:#{new_resource.port} #{key_type} #{new_resource.key}"
+    else
+      key = "#{new_resource.host} #{key_type} #{new_resource.key}"
+    end
+    
   else
 
-    key = `ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}`
+    keyscan_result = `ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}`
+
+    if new_resource.port != 22
+      key = keyscan_result.sub(/^#{new_resource.host}/, "[#{new_resource.host}]:#{new_resource.port}")
+    else
+      key = keyscan_result
+    end
+    
   end
   comment = key.split("\n").first || ''
 


### PR DESCRIPTION
### Description

Handle non-standard SSH ports in the `known_hosts` file.

This PR does not include tests. It looks like the existing testing infrastructure for this cookbook doesn't have a great way to add a test for handling non-standard SSH ports. Suggestions for how to design a test for this change would be much appreciated.

This PR also adds an explicit `require 'English'`. I was seeing an error where the `/etc/ssh/ssh_known_hosts` file had no newlines in it after a chef run because `$INPUT_RECORD_SEPARATOR` was `nil`.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


