### PR TITLE
Change shellout to shell_out

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Dyanmically generates /etc/ssh/ssh_known_hosts based on search indexes'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '3.0.0'
+version           '3.0.1'
 recipe            'ssh_known_hosts', 'Provides an LWRP for managing SSH known hosts. Also includes a recipe for automatically adding all nodes to the SSH known hosts.'
 
 source_url 'https://github.com/chef-cookbooks/ssh_known_hosts' if respond_to?(:source_url)

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -36,7 +36,7 @@ action :create do
 
   else
 
-    key = shellout("ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}")
+    key = shell_out("ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}").stdout
   end
   comment = key.split("\n").first || ''
 


### PR DESCRIPTION
### Description

```
    NoMethodError
    -------------
    No resource or method named `shellout' for `LWRP provider ssh_known_hosts_entry from cookbook ssh_known_hosts ""'
```

### Issues Resolved

Change shellout to shell_out