### PR TITLE
Fixed an issue with shell-out command, removed chef-solo code, added …

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,3 +38,6 @@ suites:
   attributes:
     ssh_known_hosts:
       use_data_bag_cache: true
+- name: known_hosts_test
+  run_list:
+  - recipe[ssh_known_hosts_test]

--- a/README.md
+++ b/README.md
@@ -69,39 +69,12 @@ The following attributes are set on a per-platform basis, see the `attributes/de
 
 #### LWRP Attributes
 
-<table>
-  <thead>
-    <tr>
-      <th>Attribute</th>
-      <th>Description</th>
-      <th>Example</th>
-      <th>Default</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>host</td>
-      <td>the host to add</td>
-      <td><tt>github.com</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>key</td>
-      <td>(optional) provide your own key</td>
-      <td><tt>ssh-rsa ...</tt></td>
-      <td><tt>ssh-keyscan -H #{host}</tt></td>
-    </tr>
-    <tr>
-      <td>port</td>
-      <td>(optional) the server port that ssh-keyscan will use to gather the public key</td>
-      <td><tt>2222</tt></td>
-      <td><tt>22</tt></td>
-    </tr>
-  </tbody>
-</table>
-
-- - -
+| Attribute | Description                                                                  | Example       | Default                |
+|-----------|------------------------------------------------------------------------------|---------------|------------------------|
+| host      | the host to add                                                              | github.com    |                        |
+| key       | (optional) provide your own key                                              | ssh-rsa ...   | ssh-keyscan -H #{host} |
+| port      | (optional) the server port that ssh-keyscan will use to gater the public key | 2222          | 22                     |
+| timeout   | (optional) limit the length of time ssh-keyscan will run for  (seconds)      | 90            | 30                     |
 
 ### Default Recipe
 
@@ -121,55 +94,15 @@ There are two ways to add custom host keys. You can either use the provided LWRP
 
 There are additional optional values you may use in the data bag:
 
-<table>
-  <thead>
-    <tr>
-      <th>Attribute</th>
-      <th>Description</th>
-      <th>Example</th>
-      <th>Default</th>
-    </tr>
-  </thead>
 
-  <tbody>
-    <tr>
-      <td>id</td>
-      <td>a unique id for this data bag entry</td>
-      <td><tt>github</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>fqdn</td>
-      <td>the fqdn of the host</td>
-      <td><tt>github.com</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>rsa</td>
-      <td>the rsa key for this server</td>
-      <td><tt>ssh-rsa AAAAB3...</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>ipaddress</td>
-      <td>the ipaddress of the node (if fqdn is missing)</td>
-      <td><tt>1.1.1.1</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>hostname</td>
-      <td>local hostname of the server (if not a fqdn)</td>
-      <td><tt>myserver.local</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>dsa</td>
-      <td>the dsa key for this server</td>
-      <td><tt>ssh-dsa ABAAC3...</tt></td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+| Attribute | Description                                         | Example           |
+|-----------|-----------------------------------------------------|-------------------|
+| id        | a unique id for this data bag entry                 | github            |
+| fqdn      | the fqdn of the host                                | github.com        |
+| rsa       | the rsa key for this server                         | ssh-rsa AAAAB3... |
+| ipaddress | the ipaddress of the node (if fqdn is not supplied) | 1.1.1.1           |
+| hostname  | local hostname of the server (if not a fqdn)        | myserver.local    |
+| dsa       | the dsa key for this server                         | ssh-dsa ABAAC3... |
 
 ### ChefSpec matchers
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Dyanmically generates /etc/ssh/ssh_known_hosts based on search indexes'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '3.0.0'
+version           '3.0.1'
 recipe            'ssh_known_hosts', 'Provides an LWRP for managing SSH known hosts. Also includes a recipe for automatically adding all nodes to the SSH known hosts.'
 
 source_url 'https://github.com/chef-cookbooks/ssh_known_hosts' if respond_to?(:source_url)
-issues_url 'https://github.com/chef-cookbooks/motd-tail/ssh_known_hosts' if respond_to?(:issues_url)
+issues_url 'https://github.com/chef-cookbooks/ssh_known_hosts' if respond_to?(:issues_url)

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -35,16 +35,17 @@ action :create do
     key = "#{new_resource.host} #{key_type} #{new_resource.key}"
   else
     keyscan = shell_out!("ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}", timeout: new_resource.timeout)
+    key = keyscan.stdout
   end
 
-  comment = keyscan.stdout.split("\n").first || ''
+  comment = key.stdout.split("\n").first || ''
 
-  if key_exists?(keyscan.stdout, comment)
+  if key_exists?(key, comment)
     Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
   else
     require 'English'
 
-    new_keys = (keys + [keyscan.stdout]).uniq.sort
+    new_keys = (keys + [key]).uniq.sort
     file "ssh_known_hosts-#{new_resource.name}" do
       path node['ssh_known_hosts']['file']
       action :create

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -38,7 +38,7 @@ action :create do
     key = keyscan.stdout
   end
 
-  comment = key.stdout.split("\n").first || ''
+  comment = key.split("\n").first || ''
 
   if key_exists?(key, comment)
     Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -33,12 +33,11 @@ action :create do
                end
 
     key = "#{new_resource.host} #{key_type} #{new_resource.key}"
-
   else
-
-    key = shellout("ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}")
+    keyscan = shell_out!("ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}", timeout: new_resource.timeout)
   end
-  comment = key.split("\n").first || ''
+
+  comment = keyscan.stdout.split("\n").first || ''
 
   if key_exists?(key, comment)
     Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"

--- a/providers/entry.rb
+++ b/providers/entry.rb
@@ -39,12 +39,12 @@ action :create do
 
   comment = keyscan.stdout.split("\n").first || ''
 
-  if key_exists?(key, comment)
+  if key_exists?(keyscan.stdout, comment)
     Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
   else
     require 'English'
 
-    new_keys = (keys + [key]).uniq.sort
+    new_keys = (keys + [keyscan.stdout]).uniq.sort
     file "ssh_known_hosts-#{new_resource.name}" do
       path node['ssh_known_hosts']['file']
       action :create

--- a/recipes/cacher.rb
+++ b/recipes/cacher.rb
@@ -1,11 +1,6 @@
-# Gather a list of all nodes, warning if using Chef Solo
-if Chef::Config[:solo]
-  raise 'ssh_known_hosts::cacher requires Chef search - Chef Solo does ' \
-    'not support search!'
-else
-  all_host_keys = SshknownhostsCookbook::KeysSearch.hosts_keys('keys:*')
-  Chef::Log.debug("Partial search got: #{all_host_keys.inspect}")
-end
+
+all_host_keys = SshknownhostsCookbook::KeysSearch.hosts_keys('keys:*')
+Chef::Log.debug("Partial search got: #{all_host_keys.inspect}")
 
 new_data_bag_content = {
   'id' => node['ssh_known_hosts']['cacher']['data_bag_item'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,13 +32,6 @@ if node['ssh_known_hosts']['use_data_bag_cache']
     node['ssh_known_hosts']['cacher']['data_bag_item']
   )['keys']
   Chef::Log.info "hosts data bag: #{hosts.inspect}"
-elsif Chef::Config[:solo]
-  # Gather a list of all nodes, warning if using Chef Solo
-
-  Chef::Log.warn 'ssh_known_hosts requires Chef search - Chef Solo does not support search!'
-
-  # On Chef Solo, we still want the current node to be in the ssh_known_hosts
-  hosts = [node]
 else
   hosts = SshknownhostsCookbook::KeysSearch.hosts_keys("keys_ssh:* NOT name:#{node.name}")
 end

--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -23,6 +23,7 @@ attribute :host, kind_of: String, name_attribute: true
 attribute :key, kind_of: String
 attribute :key_type, kind_of: String, default: 'rsa'
 attribute :port, kind_of: Fixnum, default: 22
+attribute :timeout, kind_of: Fixnum, default: 30
 
 def initialize(*args)
   super

--- a/test/fixtures/cookbooks/ssh_known_hosts_test/README.md
+++ b/test/fixtures/cookbooks/ssh_known_hosts_test/README.md
@@ -1,4 +1,4 @@
 ssh_known_hosts_test
 ====================
 
-An cookbook for testing ssh_known_hosts
+A cookbook for testing ssh_known_hosts


### PR DESCRIPTION
### Description

Fixed an issue with shell-out command, removed chef-solo code, added timeout attribute to entry resource

In this commit, there are a few fixes. The README has been updated with current documentation adding the timeout attribute to the resource, and clearing up the table html that was messing up presentation on the supermarket site. 

There was an error in the issues location, which has been fixed in metadata.

The cacher and default recipes had chef-solo code that has been removed.

The entry provider code around shell_out was incorrect. This was discovered by realizing that there was no path of code that was testing whether keyscan worked. A test suite was added to .kitchen.yml to cover that using the fixture ssh_known_hosts_test cookbook.

### Issues Resolved

Issue #47 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD