### PR TITLE
use delayed accumulator pattern

### DIFF
--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -45,7 +45,7 @@ action :create do
   comment = key.split("\n").first || ''
 
   r = with_run_context :root do
-    # XXX: remove once delayed_actions lands in compat_resource
+    # XXX: remove log resource once delayed_actions lands in compat_resource
     find_resource(:log, "force delayed notification") do
       notifies :create, "file[update ssh known hosts file]", :delayed
     end

--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -60,22 +60,22 @@ action :create do
     end
   end
 
-  if key_exists?(key_array(r.content), key, comment)
+  keys = key_array(r.content)
+
+  if key_exists?(keys, key, comment)
     Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
   else
-    r.content << key << "\n"
-    # FIXME: unsorted for now, and isn't uniq redundant with the check above?
-    # new_keys = (keys + [key]).uniq.sort
+    r.content keys.push(key).sort.uniq.join("\n") << "\n"
   end
 end
 
 action_class do
-  def key_array(keys)
-    keys.split("\n").reject(&:empty?)
+  def key_array(keystr)
+    keystr.split("\n").reject(&:empty?)
   end
 
-  def key_exists?(key_array, key, comment)
-    key_array.any? do |line|
+  def key_exists?(keys, key, comment)
+    keys.any? do |line|
       line.match(/#{Regexp.escape(comment)}|#{Regexp.escape(key)}/)
     end
   end

--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -46,17 +46,17 @@ action :create do
 
   r = with_run_context :root do
     # XXX: remove log resource once delayed_actions lands in compat_resource
-    find_resource(:log, "force delayed notification") do
-      notifies :create, "file[update ssh known hosts file]", :delayed
+    find_resource(:log, 'force delayed notification') do
+      notifies :create, 'file[update ssh known hosts file]', :delayed
     end
-    find_resource(:file, "update ssh known hosts file") do
+    find_resource(:file, 'update ssh known hosts file') do
       path node['ssh_known_hosts']['file']
       owner new_resource.owner
       group new_resource.group
       mode new_resource.mode
       action :nothing
       backup false
-      content ""
+      content ''
     end
   end
 

--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -30,7 +30,6 @@ attribute :group, kind_of: String, default: 'root'
 
 action :create do
   if new_resource.key
-
     key_type = if new_resource.key_type == 'rsa' || new_resource.key_type == 'dsa'
                  "ssh-#{new_resource.key_type}"
                else
@@ -45,43 +44,38 @@ action :create do
 
   comment = key.split("\n").first || ''
 
-  if key_exists?(key, comment)
-    Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
-  else
-    require 'English'
-
-    new_keys = (keys + [key]).uniq.sort
-    file "ssh_known_hosts-#{new_resource.name}" do
+  r = with_run_context :root do
+    # XXX: remove once delayed_actions lands in compat_resource
+    find_resource(:log, "force delayed notification") do
+      notifies :create, "file[update ssh known hosts file]", :delayed
+    end
+    find_resource(:file, "update ssh known hosts file") do
       path node['ssh_known_hosts']['file']
       owner new_resource.owner
       group new_resource.group
       mode new_resource.mode
-      action :create
+      action :nothing
       backup false
-      content "#{new_keys.join($RS)}#{$RS}"
+      content ""
     end
+  end
+
+  if key_exists?(key_array(r.content), key, comment)
+    Chef::Log.debug "Known hosts key for #{new_resource.name} already exists - skipping"
+  else
+    r.content << key << "\n"
+    # FIXME: unsorted for now, and isn't uniq redundant with the check above?
+    # new_keys = (keys + [key]).uniq.sort
   end
 end
 
 action_class do
-  def keys
-    unless @keys
-      if key_file_exists?
-        lines = ::File.readlines(node['ssh_known_hosts']['file'])
-        @keys = lines.map(&:chomp).reject(&:empty?)
-      else
-        @keys = []
-      end
-    end
-    @keys
+  def key_array(keys)
+    keys.split("\n").reject(&:empty?)
   end
 
-  def key_file_exists?
-    ::File.exist?(node['ssh_known_hosts']['file'])
-  end
-
-  def key_exists?(key, comment)
-    keys.any? do |line|
+  def key_exists?(key_array, key, comment)
+    key_array.any? do |line|
       line.match(/#{Regexp.escape(comment)}|#{Regexp.escape(key)}/)
     end
   end


### PR DESCRIPTION
uses an accumulator pattern

fixes at least part of #43 -- although that is a badly written issue that confuses multiple issues together

this will fire one single resource off at the end of the run which manage the entire file

if the file does not change, i believe no resources will be updated by chef-client

this is probably a major change and has a breaking change in it.

the breaking change is that since we never write the known_hosts file until the end, resources in the middle of the run do not see the partially-written file as the chef-client run proceeds so may fail on first bootstrap before the ssh_known_hosts file is seeded.  since having the ssh_known_hosts file being progressively emptied and filled throughout the chef-client run is fairly terrible behavior that could also break production use of ssh if some other process loses a race and runs while chef-client is emptying out the file, i think this is acceptable behavior.

users should probably write files into e.g. /root/.ssh/known_hosts for keys that chef-client itself needs in order to complete and should not rely on the global ssh_known_hosts file.

i can't think of a better fix to this, and think users should likely just be broken and need to change their approach, since the only fix i can come up with is allowing some kind of flag which would force an immediate and partial flush of the resource, which is always terrible because of the prior rationale.

EDIT: oh yeah, since this is chef and since i included a convenient statically named function, users can do whatever they want, and I can't stop them:

```ruby
# i certify that i really know that i've completely accumulated all my ssh_known_hosts entries at this point, and i really know i won't hose some poor sap that comes after me
find_resource(:file, "update ssh known hosts file").run_action(:create)
```

closes #43 

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>