### PR TITLE
do not write port number if it is 22

### DIFF
--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -43,7 +43,7 @@ end
 action :create do
   key =
     if new_resource.key
-      hoststr = new_resource.port ? "[#{new_resource.host}]:#{new_resource.port}" : new_resource.host
+      hoststr = (new_resource.port != 22) ? "[#{new_resource.host}]:#{new_resource.port}" : new_resource.host
       "#{hoststr} #{type_string(new_resource.key_type)} #{new_resource.key}"
     else
       keyscan = shell_out!("ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}", timeout: new_resource.timeout)


### PR DESCRIPTION
Generated ssh_known_hosts was not working for hosts on the default port. (Maybe syntax for specifying port is broken?)

Before merging, please verify that removing the port specification does not add the key as accepted for all ports, which may be undesirable.

Obvious fix.


