### PR TITLE
add support for hashed entries when using keyscan

### DIFF
--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -27,6 +27,7 @@ attribute :timeout, kind_of: Integer, default: 30
 attribute :mode, kind_of: String, default: '0644'
 attribute :owner, kind_of: String, default: 'root'
 attribute :group, kind_of: String, default: 'root'
+attribute :hash_entries, equal_to: [true, false], default: false
 
 action_class do
   def type_string(key_type)
@@ -46,7 +47,10 @@ action :create do
       hoststr = (new_resource.port != 22) ? "[#{new_resource.host}]:#{new_resource.port}" : new_resource.host
       "#{hoststr} #{type_string(new_resource.key_type)} #{new_resource.key}"
     else
-      keyscan = shell_out!("ssh-keyscan -t#{node['ssh_known_hosts']['key_type']} -p #{new_resource.port} #{new_resource.host}", timeout: new_resource.timeout)
+      keyscan_cmd = ['ssh-keyscan', "-t#{node['ssh_known_hosts']['key_type']}", "-p #{new_resource.port}"]
+      keyscan_cmd << '-H' if new_resource.hash_entries
+      keyscan_cmd << new_resource.host
+      keyscan = shell_out!(keyscan_cmd.join(' '), timeout: new_resource.timeout)
       keyscan.stdout
     end
 


### PR DESCRIPTION
### Description

This permits us to generate hashed ssh_known_hosts entries, solely when using the keyscan code path

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
