### PR TITLE
Correct function names in 'deprecated' recipe

### DIFF
--- a/recipes/deprecated.rb
+++ b/recipes/deprecated.rb
@@ -2,7 +2,7 @@ include_recipe "::default"
 
 # read in all the old information
 lines = ::File.readlines(node['ssh_known_hosts']['file'])
-hosts = lines.map(&:chmop).reject(&:empty).map do |line|
+hosts = lines.map(&:chomp).reject(&:empty?).map do |line|
   fields = line.split(/\s+/)
   {
     "fqdn" => fields[0],


### PR DESCRIPTION
### Description

Corrects the function names in the deprecated recipe.  "chmop" -> "chomp", "empty" -> "empty?"

Obvous fix.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
