### PR TITLE
Removed :delayed property from ssh known hosts template

### DIFF
--- a/resources/entry.rb
+++ b/resources/entry.rb
@@ -59,17 +59,13 @@ action :create do
   comment = key.split("\n").first || ''
 
   r = with_run_context :root do
-    # XXX: remove log resource once delayed_actions lands in compat_resource
-    find_resource(:log, 'force delayed notification') do
-      notifies :create, 'template[update ssh known hosts file]', :delayed
-    end
     find_resource(:template, 'update ssh known hosts file') do
       source 'ssh_known_hosts.erb'
       path node['ssh_known_hosts']['file']
       owner new_resource.owner
       group new_resource.group
       mode new_resource.mode
-      action :nothing
+      action :create
       backup false
       variables(entries: [])
     end


### PR DESCRIPTION
A delayed property on the update ssh known hosts file template caused
issue #77. Without the delayed property, the ssh_known_hosts file is
updated as expected.

Signed-off-by: Pierre Beucher <beucher.pierre@gmail.com>

### Issues Resolved

#77: Using recently added ssh host does not work until next provision/converge

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
