### PR TITLE
Write out FQDN, short name, and IP address if we have all values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the ssh_known_hosts cookbook.
 
+## Unreleased
+
+- Put all machine identities into known hosts file
+
 ## 7.0.0 (2019-06-10)
 
 ### Breaking Changes

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,7 +34,7 @@ suites:
   - recipe[ssh_known_hosts_test::default]
   attributes:
     ssh_known_hosts:
-      node_query_search: 'AND chef_environment:stage'
+      node_search_query: 'AND chef_environment:stage'
 - name: cacher
   run_list:
   - recipe[ssh_known_hosts_test::cacher]

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -78,7 +78,7 @@ module SshknownhostsRecipeHelpers
 
   # takes node-ish object and finds a useful enough fqdn
   def fqdn_from_node(node)
-    node['fqdn'] || node['ipaddress'] || node['hostname']
+    [node['fqdn'], node['ipaddress'], node['hostname']].reject { |n| n.nil? || n.empty? }.join(',')
   end
 
   def key_types_from_node(data)

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -4,9 +4,9 @@ describe 'Known Hosts' do
   # This here is some serious voodoo but it SHOULD work and provide a good
   # test.
   describe file('/etc/ssh/ssh_known_hosts') do
-    its(:content) { should include "ssh-rsa TEST_RSA_PUBLIC_KEY_HOST-1\n" }
-    its(:content) { should include "ecdsa-sha2-nistp256 TEST_ECDSA_PUBLIC_KEY_HOST-2\n" }
-    its(:content) { should include "ssh-ed25519 TEST_ED25519_PUBLIC_KEY_HOST-3\n" }
+    its(:content) { should include "host-1.vagrantup.com,10.0.2.16,host-1 ssh-rsa TEST_RSA_PUBLIC_KEY_HOST-1\n" }
+    its(:content) { should include "host-2.vagrantup.com,10.0.2.17 ecdsa-sha2-nistp256 TEST_ECDSA_PUBLIC_KEY_HOST-2\n" }
+    its(:content) { should include "host-3.vagrantup.com,host-3 ssh-ed25519 TEST_ED25519_PUBLIC_KEY_HOST-3\n" }
     it { should be_mode 644 }
     it { should be_owned_by 'root' }
   end

--- a/test/integration/nodes/host-2.json
+++ b/test/integration/nodes/host-2.json
@@ -1,7 +1,7 @@
 {
   "name": "host-2",
   "automatic": {
-    "hostname": "host-2",
+    "hostname": "",
     "fqdn": "host-2.vagrantup.com",
     "ipaddress": "10.0.2.17",
     "keys": {

--- a/test/integration/nodes/host-3.json
+++ b/test/integration/nodes/host-3.json
@@ -3,7 +3,6 @@
   "automatic": {
     "hostname": "host-3",
     "fqdn": "host-3.vagrantup.com",
-    "ipaddress": "10.0.2.17",
     "keys": {
       "ssh": {
         "host_rsa_public": "TEST_RSA_PUBLIC_KEY_HOST-3",


### PR DESCRIPTION
Updated an existing PR to have latest changes. 

### Description
Instead of only adding the fqdn to the ssh_known_hosts file, This change also writes the short hostname and IP address (if available).

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>